### PR TITLE
Move used libraries to actual dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "author": "Andris Reinman",
   "license": "MIT",
   "dependencies": {
-    "libmime": "^2.1.2"
+    "libbase64": "^0.1.0",
+    "libmime": "^2.1.2",
+    "libqp": "^1.1.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-nodeunit": "^1.0.0",
     "grunt-eslint": "^19.0.0",
-    "libbase64": "^0.1.0",
-    "libqp": "^1.1.0",
     "random-message": "^1.1.0"
   },
   "files": [


### PR DESCRIPTION
lib/mime-node.js depends on these modules.

While this works fine on npm3 through transitive dependencies via libmime, it breaks on npm2.