### PR TITLE
update libbase64 to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "EUPL-1.1",
   "dependencies": {
     "libmime": "3.1.0",
-    "libbase64": "0.1.0",
+    "libbase64": "1.0.1",
     "libqp": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We have an issue with `libbase64 version 0.1.0` when the length of the attachment falls into `if (length % 4)`. I tested locally the newest version of `libbase (1.0.1)` and looks like it is working fine. Probably the latest commits fixed the issue.

So this commit is to update `mailsplit` which relies on `libbase64` so that `mailpaser` includes the fixes too.