### PR TITLE
Manage multipart with header only

### DIFF
--- a/lib/message-splitter.js
+++ b/lib/message-splitter.js
@@ -332,6 +332,11 @@ class MessageSplitter extends Transform {
                     break;
                 }
                 case 4:
+                    // special case when boundary close a node with only header.
+                    if (this.node && this.node._headerlen && !this.node.headers) {
+                        this.node.parseHeaders();
+                        this.push(this.node);
+                    }
                     // move up
                     if (this.tree.length) {
                         this.node = this.tree.pop();


### PR DESCRIPTION
To fix issue #5 

When an email contain a multipart rfc822
with in it an email that contain header only
the email was not send by the spliter.