### PR TITLE
Don't create a message node for EML attachments unless there is `Content-Disposition: inline`

### DIFF
--- a/lib/message-splitter.js
+++ b/lib/message-splitter.js
@@ -374,7 +374,7 @@ class MessageSplitter extends Transform {
                         currentNode.contentType === 'message/rfc822' &&
                         !this.config.ignoreEmbedded &&
                         (!currentNode.encoding || ['7bit', '8bit', 'binary'].includes(currentNode.encoding)) &&
-                        currentNode.disposition !== 'attachment'
+                        currentNode.disposition === 'inline'
                     ) {
                         currentNode.messageNode = true;
                         this.newNode(currentNode);

--- a/test/message-splitter-test.js
+++ b/test/message-splitter-test.js
@@ -387,6 +387,69 @@ module.exports['Split multipart message with embedded message/rfc88'] = test => 
     );
 };
 
+module.exports['Split multipart message with embedded inline message/rfc88'] = test => {
+  let splitter = new MessageSplitter();
+
+  let tests = [
+    data => {
+      test.equal(data.type, 'node');
+      test.equal(
+        data.getHeaders().toString(),
+        'Content-type: multipart/mixed; boundary=ABC\r\nX-Test: =?UTF-8?Q?=C3=95=C3=84?= =?UTF-8?Q?=C3=96=C3=9C?=\r\nSubject: ABCDEF\r\n\r\n'
+      );
+    },
+    data => {
+      test.equal(data.type, 'data');
+      test.equal(data.value.toString(), '--ABC\n');
+    },
+    data => {
+      test.equal(data.type, 'node');
+      test.equal(data.getHeaders().toString(), 'Content-Type: message/rfc822\r\nContent-Disposition: inline\r\n\r\n');
+    },
+    data => {
+      test.equal(data.type, 'node');
+      test.equal(data.getHeaders().toString(), 'Content-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n\r\n');
+    },
+    data => {
+      test.equal(data.type, 'body');
+      test.equal(data.value.toString(), 'AAECAwQFBg==');
+    },
+    data => {
+      test.equal(data.type, 'data');
+      test.equal(data.value.toString(), '\r\n--ABC--');
+    }
+  ];
+  test.expect(18);
+
+  splitter.on('data', data => {
+    let nextTest = tests.shift();
+    test.ok(nextTest);
+    nextTest(data);
+  });
+
+  splitter.on('end', () => {
+    test.done();
+  });
+
+  splitter.end(
+    Buffer.from(
+      'Content-type: multipart/mixed; boundary=ABC\r\n' +
+      'X-Test: =?UTF-8?Q?=C3=95=C3=84?= =?UTF-8?Q?=C3=96=C3=9C?=\r\n' +
+      'Subject: ABCDEF\r\n' +
+      '\r\n' +
+      '--ABC\n' +
+      'Content-Type: message/rfc822\r\n' +
+      'Content-Disposition: inline\r\n' +
+      '\r\n' +
+      'Content-Type: text/plain\r\n' +
+      'Content-Transfer-Encoding: base64\r\n' +
+      '\r\n' +
+      'AAECAwQFBg==\r\n' +
+      '--ABC--'
+    )
+  );
+};
+
 module.exports['Split multipart message with embedded message/rfc822 with header only'] = test => {
     let splitter = new MessageSplitter();
 

--- a/test/message-splitter-test.js
+++ b/test/message-splitter-test.js
@@ -349,19 +349,15 @@ module.exports['Split multipart message with embedded message/rfc88'] = test => 
             test.equal(data.getHeaders().toString(), 'Content-Type: message/rfc822\r\n\r\n');
         },
         data => {
-            test.equal(data.type, 'node');
-            test.equal(data.getHeaders().toString(), 'Content-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n\r\n');
-        },
-        data => {
             test.equal(data.type, 'body');
-            test.equal(data.value.toString(), 'AAECAwQFBg==');
+            test.equal(data.value.toString(), 'Content-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n\r\nAAECAwQFBg==');
         },
         data => {
             test.equal(data.type, 'data');
             test.equal(data.value.toString(), '\r\n--ABC--');
         }
     ];
-    test.expect(18);
+    test.expect(15);
 
     splitter.on('data', data => {
         let nextTest = tests.shift();
@@ -408,12 +404,12 @@ module.exports['Split multipart message with embedded message/rfc822 with header
             test.equal(data.getHeaders().toString(), 'Content-Type: message/rfc822\r\n\r\n');
         },
         data => {
-            test.equal(data.type, 'node');
-            test.equal(data.getHeaders().toString(), 'Content-Type: text/plain; charset=utf-8\r\nSubject: OK\r\n');
+            test.equal(data.type, 'body');
+            test.equal(data.value.toString(), 'Content-Type: text/plain; charset=utf-8\r\nSubject: OK');
         },
         data => {
             test.equal(data.type, 'data');
-            test.equal(data.value.toString(), '--ABC--');
+            test.equal(data.value.toString(), '\r\n--ABC--');
         }
     ];
     test.expect(15);


### PR DESCRIPTION
This makes sure that we stay consistent with other attachment types.