### PR TITLE
fix node 18 breakage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+on: push
+
+jobs:
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [^12, ^14, ^16, ^18]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: install
+        run: npm install
+
+      - name: test
+        run: npm test

--- a/lib/message-splitter.js
+++ b/lib/message-splitter.js
@@ -25,7 +25,6 @@ class MessageSplitter extends Transform {
         this.newNode();
         this.tree.push(this.node);
         this.line = false;
-        this.errored = false;
     }
 
     _transform(chunk, encoding, callback) {
@@ -78,7 +77,6 @@ class MessageSplitter extends Transform {
 
                     return this.processLine(chunk.slice(start, i), false, (err, data, flush) => {
                         if (err) {
-                            this.errored = true;
                             return setImmediate(() => callback(err));
                         }
 

--- a/test/message-splitter-test.js
+++ b/test/message-splitter-test.js
@@ -668,6 +668,7 @@ module.exports['Fail on large header'] = test => {
     splitter.once('error', err => {
         test.ok(err);
         test.done();
+        splitter.destroy(err);
     });
 
     splitter.once('end', () => {


### PR DESCRIPTION
setting the `errored` property is a fatal operation under node 18. removing the offending lines seems to make no difference for the tests. i've added a github actions workflow for running the tests under various nodes, as well as fixed a test that was failing under node 12.